### PR TITLE
Fix Naming Of Storj

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 This repository contains code to facilitate running an IPFS node using the Storj network as the datastorage backend. It does this leveraging a good chunk of code that was borrowed from [go-ds-s3](https://github.com/ipfs/go-ds-s3).
 
-The immediate benefit to a system like this is a mass amount of data protection (redundancy, decentralization, and durability) not present with traditional IPFS nodes. Traditional IPFS nodes require many copies of the data to spread it amongst multiple hosts and to achieve redundancy measures. However, when combined with STORJ a single IPFS node is atuomatically distributing data across a vast number of machines accomplishing:
+The immediate benefit to a system like this is a mass amount of data protection (redundancy, decentralization, and durability) not present with traditional IPFS nodes. Traditional IPFS nodes require many copies of the data to spread it amongst multiple hosts and to achieve redundancy measures. However, when combined with Storj a single IPFS node is atuomatically distributing data across a vast number of machines accomplishing:
 
 1) Data distribution
 2) Data decentralization

--- a/s3/README.md
+++ b/s3/README.md
@@ -2,4 +2,4 @@
 
 None of this would be possible, or at the very least require a huge amount of R&D if it wasn't for the amazing people at Protocol Labs and other community contributors at the [ipfs/go-ds-s3](https://github.com/ipfs/go-ds-s3) repository.
 
-It is being modified to work better with STORJ as the datastore, avoiding the limitations and restrictions imposed by using an S3 service with a company like AWS.
+It is being modified to work better with Storj as the datastore, avoiding the limitations and restrictions imposed by using an S3 service with a company like AWS.


### PR DESCRIPTION
Correct name is `Storj` while `STORJ` is for the token.